### PR TITLE
Fix stray debug output in env module

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -16,20 +16,16 @@ from open_webui.constants import ERROR_MESSAGES
 ####################################
 
 OPEN_WEBUI_DIR = Path(__file__).parent  # the path containing this file
-print(OPEN_WEBUI_DIR)
 
 BACKEND_DIR = OPEN_WEBUI_DIR.parent  # the path containing this file
 BASE_DIR = BACKEND_DIR.parent  # the path containing the backend/
-
-print(BACKEND_DIR)
-print(BASE_DIR)
 
 try:
     from dotenv import find_dotenv, load_dotenv
 
     load_dotenv(find_dotenv(str(BASE_DIR / ".env")))
 except ImportError:
-    print("dotenv not installed, skipping...")
+    logging.getLogger(__name__).info("dotenv not installed, skipping...")
 
 DOCKER = os.environ.get("DOCKER", "False").lower() == "true"
 


### PR DESCRIPTION
## Summary
- remove stray debug `print` statements from env module
- log missing `dotenv` import instead of printing

## Testing
- `python -m py_compile backend/open_webui/env.py`
- `ruff check backend/open_webui/env.py`

------
https://chatgpt.com/codex/tasks/task_b_68416c9adcc883238f23252e157f8437