### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on signup endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Missing Signup Rate Limiting
+**Vulnerability:** The `/signup` endpoint was completely unprotected against automated abuse, allowing unlimited account creation from a single IP.
+**Learning:** While `signin` was protected, `signup` was overlooked. This highlights the importance of auditing all public write endpoints, not just authentication verification ones.
+**Prevention:** Ensure all public-facing endpoints that create resources (users, etc.) have rate limiting applied using the project's `RateLimiter` utility.

--- a/backend/answer_ai/routers/auths.py
+++ b/backend/answer_ai/routers/auths.py
@@ -85,6 +85,11 @@ signin_rate_limiter = RateLimiter(
     redis_client=get_redis_client(), limit=5 * 3, window=60 * 3
 )
 
+# 5 requests per hour (60 * 60) per IP
+signup_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=5, window=60 * 60
+)
+
 ############################
 # GetSessionUser
 ############################
@@ -641,6 +646,12 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
+    if signup_rate_limiter.is_limited(request.client.host):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
     has_users = Users.has_users()
 
     if ANSWERAI_AUTH:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/signup` endpoint lacked rate limiting, allowing unlimited account creation.
🎯 Impact: Attackers could flood the database with spam users, potentially causing Denial of Service (DoS) or resource exhaustion.
🔧 Fix: Implemented `RateLimiter` on the `/signup` endpoint, restricting it to 5 requests per hour per IP.
✅ Verification: Verified using a reproduction script (`verify_signup_ratelimit.py`) that successfully blocked requests after the 5th attempt.

---
*PR created automatically by Jules for task [6686032227243415749](https://jules.google.com/task/6686032227243415749) started by @aditya-gaharawar*