### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limit on signup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Signup Rate Limiting & Testing
+**Vulnerability:** Missing rate limiting on `/signup` allowed unrestricted account creation.
+**Learning:** The `signup` endpoint logic automatically disables the signup feature (`ENABLE_SIGNUP = False`) if it detects that the first user was just created (`Users.has_users()` returns False). This creates a testing challenge where subsequent requests in a test loop fail with 403 Forbidden instead of hitting the rate limiter, unless the test environment properly mocks `Users.has_users()` to return `True` (simulating existing users) after the first request.
+**Prevention:** When testing authentication flows that have "first-run" logic, ensure the test state transitions correctly or mock the state to simulate a stable system to verify repetitive behaviors like rate limiting.

--- a/backend/answer_ai/routers/auths.py
+++ b/backend/answer_ai/routers/auths.py
@@ -85,6 +85,10 @@ signin_rate_limiter = RateLimiter(
     redis_client=get_redis_client(), limit=5 * 3, window=60 * 3
 )
 
+signup_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=5, window=60 * 60
+)
+
 ############################
 # GetSessionUser
 ############################
@@ -641,6 +645,12 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
+    if request.client and signup_rate_limiter.is_limited(request.client.host):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
     has_users = Users.has_users()
 
     if ANSWERAI_AUTH:

--- a/backend/answer_ai/test/apps/answerai/routers/test_signup_ratelimit_mock.py
+++ b/backend/answer_ai/test/apps/answerai/routers/test_signup_ratelimit_mock.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from answer_ai.routers import auths
+
+# Create a minimal app with just the auth router
+app = FastAPI()
+app.include_router(auths.router, prefix="/api/v1/auths")
+
+# Mock app state
+app.state.config = MagicMock()
+app.state.config.ENABLE_SIGNUP = True
+app.state.config.ENABLE_LOGIN_FORM = True
+app.state.config.JWT_EXPIRES_IN = "1h"
+app.state.config.DEFAULT_GROUP_ID = "1"
+app.state.config.USER_PERMISSIONS = {}
+app.state.config.WEBHOOK_URL = ""
+app.state.ANSWERAI_NAME = "AnswerAI"
+
+client = TestClient(app)
+
+def test_signup_rate_limit():
+    # Force the rate limiter to use memory store and clear it
+    auths.signup_rate_limiter.r = None
+    auths.signup_rate_limiter._memory_store = {}
+    auths.signup_rate_limiter.enabled = True
+
+    # Mock dependencies
+    with patch("answer_ai.routers.auths.Users") as mock_users, \
+         patch("answer_ai.routers.auths.Auths") as mock_auths, \
+         patch("answer_ai.routers.auths.validate_email_format", return_value=True), \
+         patch("answer_ai.routers.auths.validate_password"), \
+         patch("answer_ai.routers.auths.get_password_hash", return_value="hashed"), \
+         patch("answer_ai.routers.auths.create_token", return_value="token"), \
+         patch("answer_ai.routers.auths.get_permissions", return_value={}), \
+         patch("answer_ai.routers.auths.apply_default_group_assignment"), \
+         patch("answer_ai.routers.auths.post_webhook"):
+
+        # Setup mocks - simulate existing users so we don't trigger "first user" logic which disables signup
+        mock_users.has_users.return_value = True
+        mock_users.get_user_by_email.return_value = None
+
+        mock_user = MagicMock()
+        mock_user.id = "123"
+        mock_user.email = "test@example.com"
+        mock_user.name = "Test"
+        mock_user.role = "user"
+        mock_user.profile_image_url = ""
+        mock_user.model_dump_json.return_value = "{}"
+
+        mock_auths.insert_new_auth.return_value = mock_user
+        mock_auths.authenticate_user_by_email.return_value = mock_user
+
+        # Make 5 requests (allowed)
+        for i in range(5):
+            response = client.post(
+                "/api/v1/auths/signup",
+                json={
+                    "name": "Test",
+                    "email": f"test{i}@example.com",
+                    "password": "password"
+                }
+            )
+            assert response.status_code == 200, f"Request {i+1} failed: {response.text}"
+
+        # Make 6th request (should be blocked)
+        response = client.post(
+            "/api/v1/auths/signup",
+            json={
+                "name": "Test",
+                "email": "test6@example.com",
+                "password": "password"
+            }
+        )
+        assert response.status_code == 429
+        assert "API rate limit exceeded" in response.text


### PR DESCRIPTION
**Vulnerability:** The `/signup` endpoint lacked rate limiting, allowing an attacker to create an unlimited number of accounts from a single IP address, potentially leading to database flooding or resource exhaustion.

**Fix:**
- Added `signup_rate_limiter` to `backend/answer_ai/routers/auths.py`.
- Configured limit: 5 requests per hour (3600 seconds).
- Applied the check at the beginning of the `signup` function using `request.client.host` as the key.
- Returns `429 Too Many Requests` with "API rate limit exceeded" if the limit is reached.

**Verification:**
- Created a mock unit test `backend/answer_ai/test/apps/answerai/routers/test_signup_ratelimit_mock.py` that simulates 6 signup requests and asserts the 6th one is blocked.
- The test mocks `Users`, `Auths`, and `RateLimiter` (forcing in-memory storage) to ensure isolation and reliability without external dependencies like Redis or Postgres.


---
*PR created automatically by Jules for task [17342036583488104176](https://jules.google.com/task/17342036583488104176) started by @aditya-gaharawar*