### PR TITLE
Shield 🛡️: Add rate limiting to signup endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-05-27 - Missing Rate Limiting on Signup
+
+**Vulnerability:** The `/signup` endpoint in `backend/answer_ai/routers/auths.py` lacked rate limiting, allowing an attacker to flood the database with new user accounts or enumerate internal behaviors.
+
+**Learning:** Rate limiting is critical for unauthenticated endpoints, especially those that create resources (like user accounts). The existing `signin` endpoint had rate limiting, but `signup` was overlooked.
+
+**Prevention:** Always verify that public endpoints, especially those involving resource creation or authentication, have appropriate rate limiting controls. Use the `RateLimiter` class consistently across all auth endpoints.

--- a/backend/answer_ai/routers/auths.py
+++ b/backend/answer_ai/routers/auths.py
@@ -85,6 +85,10 @@ signin_rate_limiter = RateLimiter(
     redis_client=get_redis_client(), limit=5 * 3, window=60 * 3
 )
 
+signup_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=5, window=3600
+)
+
 ############################
 # GetSessionUser
 ############################
@@ -641,6 +645,14 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
+    if signup_rate_limiter.is_limited(
+        request.client.host if request.client else "unknown"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
     has_users = Users.has_users()
 
     if ANSWERAI_AUTH:


### PR DESCRIPTION
Added rate limiting to the signup endpoint to prevent abuse.
- Limit: 5 requests per hour per IP.
- Implementation: Uses Redis-backed `RateLimiter` (with in-memory fallback).
- Error: Returns 429 Too Many Requests when limit is exceeded.
- Verification: Verified with a reproduction script mocking the backend environment.

---
*PR created automatically by Jules for task [9969885657210944629](https://jules.google.com/task/9969885657210944629) started by @aditya-gaharawar*