### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on signup endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [CRITICAL] Missing Rate Limiting on Signup Endpoint
+**Vulnerability:** The `/signup` endpoint lacked rate limiting, allowing a single IP address to create unlimited accounts, potentially leading to denial of service (DoS) and resource exhaustion.
+**Learning:** While the `/signin` endpoint was protected, the `/signup` endpoint was overlooked. Critical resource-creation endpoints must always be rate-limited to prevent abuse.
+**Prevention:** Always audit public endpoints (especially those creating resources like users) for rate limiting. Use shared rate limiter logic where applicable or define specific limits for sensitive actions.

--- a/backend/answer_ai/routers/auths.py
+++ b/backend/answer_ai/routers/auths.py
@@ -85,6 +85,10 @@ signin_rate_limiter = RateLimiter(
     redis_client=get_redis_client(), limit=5 * 3, window=60 * 3
 )
 
+signup_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=5, window=60 * 60
+)
+
 ############################
 # GetSessionUser
 ############################
@@ -641,6 +645,12 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
+    if signup_rate_limiter.is_limited(request.client.host or "127.0.0.1"):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
     has_users = Users.has_users()
 
     if ANSWERAI_AUTH:

--- a/backend/answer_ai/test/apps/answerai/routers/test_auths.py
+++ b/backend/answer_ai/test/apps/answerai/routers/test_auths.py
@@ -194,3 +194,40 @@ class TestAuths(AbstractPostgresTest):
             response = self.fast_api_client.get(self.create_url("/api_key"))
         assert response.status_code == 200
         assert response.json() == {"api_key": "abc"}
+
+    def test_signup_rate_limit(self):
+        from unittest.mock import patch
+
+        # Force ENABLE_SIGNUP to True to allow multiple signups
+        original_signup_setting = self.fast_api_client.app.state.config.ENABLE_SIGNUP
+        self.fast_api_client.app.state.config.ENABLE_SIGNUP = True
+
+        try:
+            # Mock Users.has_users to return True so we don't trigger "first user" logic
+            # which might disable signup or make the user admin.
+            with patch("answer_ai.routers.auths.Users.has_users", return_value=True):
+                for i in range(10):
+                    response = self.fast_api_client.post(
+                        self.create_url("/signup"),
+                        json={
+                            "name": f"User {i}",
+                            "email": f"user{i}@example.com",
+                            "password": "password",
+                        },
+                    )
+
+                    if i < 5:
+                        # The limit is 5. Expect success (200)
+                        assert (
+                            response.status_code == 200
+                        ), f"Request {i} failed with {response.status_code}: {response.text}"
+                    else:
+                        # Expect rate limit (429)
+                        assert (
+                            response.status_code == 429
+                        ), f"Request {i} should have been rate limited but got {response.status_code}"
+        finally:
+            # Restore setting
+            self.fast_api_client.app.state.config.ENABLE_SIGNUP = (
+                original_signup_setting
+            )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/signup` endpoint was missing rate limiting, allowing a single IP address to create unlimited user accounts, leading to potential DoS and resource exhaustion.
🎯 Impact: Attackers could flood the database with fake users or exhaust server resources.
🔧 Fix: Implemented a `RateLimiter` (5 requests per hour per IP) on the `/signup` endpoint in `backend/answer_ai/routers/auths.py`.
✅ Verification: Added a reproduction test case `test_signup_rate_limit` in `backend/answer_ai/test/apps/answerai/routers/test_auths.py` (verification deferred to CI due to local Docker limitations).

---
*PR created automatically by Jules for task [10016087009860939692](https://jules.google.com/task/10016087009860939692) started by @aditya-gaharawar*