### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to signup endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Missing Rate Limiting on Signup
+**Vulnerability:** The `/signup` endpoint lacked rate limiting, allowing unlimited account creation attempts from a single IP address.
+**Learning:** While `signin` had rate limiting, `signup` was overlooked. Rate limiting should be applied to all public-facing write endpoints, especially those creating resources or sending emails.
+**Prevention:** Audit all public endpoints for rate limiting. Use a shared rate limiting utility (like `RateLimiter` class) and enforce it by default or via middleware if possible.

--- a/backend/answer_ai/routers/auths.py
+++ b/backend/answer_ai/routers/auths.py
@@ -85,6 +85,10 @@ signin_rate_limiter = RateLimiter(
     redis_client=get_redis_client(), limit=5 * 3, window=60 * 3
 )
 
+signup_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=5, window=3600
+)
+
 ############################
 # GetSessionUser
 ############################
@@ -641,6 +645,14 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
+    if signup_rate_limiter.is_limited(
+        request.client.host if request.client else "unknown"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
     has_users = Users.has_users()
 
     if ANSWERAI_AUTH:


### PR DESCRIPTION
Added rate limiting to the `/signup` endpoint in `backend/answer_ai/routers/auths.py`.
Used the existing `RateLimiter` utility with a limit of 5 requests per hour, keyed by client IP.
Verified the fix using a reproduction script that mocks the application environment.
Added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17906730992093655240](https://jules.google.com/task/17906730992093655240) started by @aditya-gaharawar*