### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to signup and IP-based rate limiting to signin

### DIFF
--- a/backend/answer_ai/routers/auths.py
+++ b/backend/answer_ai/routers/auths.py
@@ -84,6 +84,12 @@ log = logging.getLogger(__name__)
 signin_rate_limiter = RateLimiter(
     redis_client=get_redis_client(), limit=5 * 3, window=60 * 3
 )
+signin_ip_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=15, window=60 * 3
+)
+signup_rate_limiter = RateLimiter(
+    redis_client=get_redis_client(), limit=5, window=60 * 60
+)
 
 ############################
 # GetSessionUser
@@ -568,7 +574,10 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
                 admin_email.lower(), lambda pw: verify_password(admin_password, pw)
             )
     else:
-        if signin_rate_limiter.is_limited(form_data.email.lower()):
+        ip = request.client.host if request.client else "127.0.0.1"
+        if signin_rate_limiter.is_limited(
+            form_data.email.lower()
+        ) or signin_ip_rate_limiter.is_limited(f"signin_ip:{ip}"):
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
@@ -641,6 +650,13 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
+    ip = request.client.host if request.client else "127.0.0.1"
+    if signup_rate_limiter.is_limited(f"signup:{ip}"):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
     has_users = Users.has_users()
 
     if ANSWERAI_AUTH:

--- a/backend/answer_ai/test/apps/answerai/routers/test_rate_limit.py
+++ b/backend/answer_ai/test/apps/answerai/routers/test_rate_limit.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from answer_ai.utils.rate_limit import RateLimiter
+from answer_ai.constants import ERROR_MESSAGES
+
+from answer_ai.main import app
+import answer_ai.routers.auths as auths_router
+
+class TestRateLimit:
+    def setup_method(self):
+        # Reset memory store before each test
+        RateLimiter._memory_store = {}
+
+    def teardown_method(self):
+        # Reset memory store after each test
+        RateLimiter._memory_store = {}
+
+    def test_signup_rate_limit(self):
+        client = TestClient(app)
+
+        # Setup mocks using patch.object
+        with patch.object(auths_router, 'Users') as mock_users, \
+             patch.object(auths_router, 'Auths') as mock_auths, \
+             patch.object(auths_router, 'apply_default_group_assignment') as mock_groups, \
+             patch.object(auths_router, 'get_permissions') as mock_perms, \
+             patch.object(auths_router, 'post_webhook') as mock_webhook:
+
+            mock_users.has_users.return_value = False
+            mock_users.get_user_by_email.return_value = None
+
+            mock_user = MagicMock()
+            mock_user.id = "1"
+            mock_user.email = "test@example.com"
+            mock_user.name = "Test"
+            mock_user.role = "admin"
+            mock_user.profile_image_url = ""
+            mock_user.model_dump_json.return_value = "{}"
+
+            mock_auths.insert_new_auth.return_value = mock_user
+            mock_perms.return_value = {}
+
+            # Force ENABLE_SIGNUP to True for the request
+            app.state.config.ENABLE_SIGNUP = True
+            app.state.config.ENABLE_LOGIN_FORM = True
+
+            for i in range(5):
+                response = client.post(
+                    "/api/v1/auths/signup",
+                    json={
+                        "name": f"User {i}",
+                        "email": f"user{i}@example.com",
+                        "password": "password123",
+                    },
+                )
+                assert response.status_code != 429
+
+            # 6th request
+            response = client.post(
+                "/api/v1/auths/signup",
+                json={
+                    "name": "User 6",
+                    "email": "user6@example.com",
+                    "password": "password123",
+                },
+            )
+            assert response.status_code == 429
+            assert response.json()["detail"] == ERROR_MESSAGES.RATE_LIMIT_EXCEEDED
+
+    def test_signin_ip_rate_limit(self):
+         client = TestClient(app)
+
+         with patch.object(auths_router, 'Users') as mock_users, \
+              patch.object(auths_router, 'Auths') as mock_auths:
+
+             # Mock authentication failure to keep it simple
+             mock_users.get_user_by_email.return_value = MagicMock()
+             mock_auths.authenticate_user.return_value = None # Fail auth
+
+             with patch("answer_ai.routers.auths.ENABLE_PASSWORD_AUTH", True):
+                 for i in range(15):
+                     response = client.post(
+                        "/api/v1/auths/signin",
+                        json={"email": f"user{i}@example.com", "password": "password"},
+                    )
+                     assert response.status_code != 429
+
+                 # 16th
+                 response = client.post(
+                    "/api/v1/auths/signin",
+                    json={"email": "final@example.com", "password": "password"},
+                )
+                 assert response.status_code == 429
+                 assert response.json()["detail"] == ERROR_MESSAGES.RATE_LIMIT_EXCEEDED


### PR DESCRIPTION
Implemented strict rate limiting on authentication endpoints to enhance security.
- `signin`: Added secondary IP-based rate limiter (15/3min) alongside existing email-based limiter.
- `signup`: Added IP-based rate limiter (5/hour).
- Verified with new unit tests in `backend/answer_ai/test/apps/answerai/routers/test_rate_limit.py`.

---
*PR created automatically by Jules for task [6233763002953504781](https://jules.google.com/task/6233763002953504781) started by @aditya-gaharawar*